### PR TITLE
Restructure rolling migration:

### DIFF
--- a/toolkit/components/passwordmgr/storage-desktop.sys.mjs
+++ b/toolkit/components/passwordmgr/storage-desktop.sys.mjs
@@ -4,150 +4,162 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- import { LoginManagerStorage_json } from "resource://gre/modules/storage-json.sys.mjs";
- import { LoginManagerRustStorage } from "resource://gre/modules/storage-rust.sys.mjs";
- 
- class MirroringObserver {
-   #rustStorage = null;
- 
-   constructor(rustStorage) {
-     this.#rustStorage = rustStorage;
-   }
- 
-   QueryInterface = ChromeUtils.generateQI([
-     "nsIObserver",
-     "nsISupportsWeakReference",
-   ]);
- 
-   async observe(subject, _, eventName) {
-     switch (eventName) {
-       case "addLogin":
-         console.log(`rust-mirror: adding login ${subject.guid}...`);
-         try {
-           // TODO: handle incompatibilities:
-           // - non-ascii origin
-           // - single dot origin
-           await this.#rustStorage.addLoginsAsync([subject]);
-         } catch (e) {
-           console.error("mirror-error:", e);
-         }
-         console.log(`rust-mirror: added login ${subject.guid}.`);
-         break;
- 
-       case "modifyLogin":
-         const loginToModify = subject.queryElementAt(0, Ci.nsILoginInfo);
-         const newLoginData = subject.queryElementAt(1, Ci.nsILoginInfo);
-         console.log(`rust-mirror: modifing login ${loginToModify.guid}...`);
-         try {
-           // TODO: handle incompatibilities:
-           // - non-ascii origin
-           // - single dot origin
-           this.#rustStorage.modifyLogin(loginToModify, newLoginData);
-         } catch (e) {
-           console.error("mirror-error:", e);
-         }
-         console.log(`rust-mirror: modified login ${loginToModify.guid}.`);
-         break;
- 
-       case "removeLogin":
-         console.log(`rust-mirror: removing login ${subject.guid}...`);
-         try {
-           this.#rustStorage.removeLogin(subject);
-         } catch (e) {
-           console.error("mirror-error:", e);
-         }
-         console.log(`rust-mirror: removed login ${subject.guid}.`);
-         break;
- 
-       case "removeAllLogins":
-         console.log("rust-mirror: removing all logins...");
-         try {
-           this.#rustStorage.removeAllLogins();
-         } catch (e) {
-           console.error("mirror-error:", e);
-         }
-         console.log("rust-mirror: removed all logins.");
-         break;
- 
-       default:
-         console.error(`mirror-error: received unhandled event "${eventName}"`);
-     }
-   }
- }
- 
- export class LoginManagerStorage extends LoginManagerStorage_json {
-   static #jsonStorage = null;
-   static #rustStorage = null;
-   static #initialized = false;
-   static #mirroringObserver = null;
- 
-   static create(callback) {
-     if (!LoginManagerStorage.#initialized) {
-       LoginManagerStorage.#jsonStorage = new LoginManagerStorage_json();
-       LoginManagerStorage.#rustStorage = new LoginManagerRustStorage();
- 
-       Promise.all([
-         LoginManagerStorage.#jsonStorage.initialize(),
-         LoginManagerStorage.#rustStorage.initialize(),
-       ]).then(async () => {
-         try {
-           await maybeRunRollingMigrationToRustStorage(
-             LoginManagerStorage.#jsonStorage,
-             LoginManagerStorage.#rustStorage
-           );
-         } catch (e) {
-           console.error("Login migration failed", e);
-         }
- 
-         LoginManagerStorage.#initialized = true;
- 
-         callback?.();
-       });
-     } else if (callback) {
-       callback();
-     }
- 
-     if (this.#mirroringObserver) {
-       Services.obs.removeObserver(
-         this.#mirroringObserver,
-         "passwordmgr-storage-changed"
-       );
-     }
-     this.#mirroringObserver = new MirroringObserver(
-       LoginManagerStorage.#rustStorage
-     );
-     Services.obs.addObserver(
-       this.#mirroringObserver,
-       "passwordmgr-storage-changed"
-     );
- 
-     return LoginManagerStorage.#jsonStorage;
-   }
- }
- 
- async function maybeRunRollingMigrationToRustStorage(jsonStore, rustStore) {
-   console.log("Running login migration...");
- 
-   const jsonChecksum = await jsonStore._store.computeHexDigest("sha256");
-   const rustCheckpoint = rustStore.store.getCheckpoint();
- 
-   if (jsonChecksum !== rustCheckpoint) {
-     console.log("Checksums differ. Rolling migration required.");
- 
-     rustStore.removeAllLogins();
-     console.log("Cleared existing Rust logins.");
- 
-     const logins = await jsonStore.getAllLogins();
- 
-     await rustStore.addLoginsAsync(logins);
-     console.log(`Successfully migrated ${logins.length} logins.`);
- 
-     rustStore.store.setCheckpoint(jsonChecksum);
-     console.log("Migration complete. Checkpoint updated.");
-   } else {
-     console.log("Checksums match. No migration needed.");
-   }
-   console.log("Login migration finished.");
- }
- 
- export { maybeRunRollingMigrationToRustStorage };
+import { LoginManagerStorage_json } from "resource://gre/modules/storage-json.sys.mjs";
+import { LoginManagerRustStorage } from "resource://gre/modules/storage-rust.sys.mjs";
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+  LoginHelper: "resource://gre/modules/LoginHelper.sys.mjs",
+});
+
+class MirroringObserver {
+  #rustStorage = null;
+
+  constructor(rustStorage) {
+    this.#rustStorage = rustStorage;
+  }
+
+  QueryInterface = ChromeUtils.generateQI([
+    "nsIObserver",
+    "nsISupportsWeakReference",
+  ]);
+
+  async observe(subject, _, eventName) {
+    switch (eventName) {
+      case "addLogin":
+        this.log(`rust-mirror: adding login ${subject.guid}...`);
+        try {
+          // TODO: handle incompatibilities:
+          // - non-ascii origin
+          // - single dot origin
+          await this.#rustStorage.addLoginsAsync([subject]);
+        } catch (e) {
+          console.error("mirror-error:", e);
+        }
+        this.log(`rust-mirror: added login ${subject.guid}.`);
+        break;
+
+      case "modifyLogin":
+        const loginToModify = subject.queryElementAt(0, Ci.nsILoginInfo);
+        const newLoginData = subject.queryElementAt(1, Ci.nsILoginInfo);
+        this.log(`rust-mirror: modifying login ${loginToModify.guid}...`);
+        try {
+          // TODO: handle incompatibilities:
+          // - non-ascii origin
+          // - single dot origin
+          this.#rustStorage.modifyLogin(loginToModify, newLoginData);
+        } catch (e) {
+          console.error("mirror-error:", e);
+        }
+        this.log(`rust-mirror: modified login ${loginToModify.guid}.`);
+        break;
+
+      case "removeLogin":
+        this.log(`rust-mirror: removing login ${subject.guid}...`);
+        try {
+          this.#rustStorage.removeLogin(subject);
+        } catch (e) {
+          console.error("mirror-error:", e);
+        }
+        this.log(`rust-mirror: removed login ${subject.guid}.`);
+        break;
+
+      case "removeAllLogins":
+        this.log("rust-mirror: removing all logins...");
+        try {
+          this.#rustStorage.removeAllLogins();
+        } catch (e) {
+          console.error("mirror-error:", e);
+        }
+        this.log("rust-mirror: removed all logins.");
+        break;
+
+      default:
+        console.error(`mirror-error: received unhandled event "${eventName}"`);
+    }
+  }
+}
+
+ChromeUtils.defineLazyGetter(MirroringObserver.prototype, "log", () => {
+  let logger = lazy.LoginHelper.createLogger("Login Mirroring Observer");
+  return logger.log.bind(logger);
+});
+
+export class LoginManagerStorage extends LoginManagerStorage_json {
+  static #jsonStorage = null;
+  static #rustStorage = null;
+  static #initialized = false;
+  static #mirroringObserver = null;
+  static #logger = lazy.LoginHelper.createLogger("Login Manager Storage");
+
+  static create(callback) {
+    LoginManagerStorage.#initialize();
+    return LoginManagerStorage.#jsonStorage;
+  }
+
+  static #initialize(callback) {
+    if (LoginManagerStorage.#initialized) {
+      return callback?.();
+    }
+
+    LoginManagerStorage.#jsonStorage = new LoginManagerStorage_json();
+    LoginManagerStorage.#rustStorage = new LoginManagerRustStorage();
+
+    return Promise.all([
+      LoginManagerStorage.#jsonStorage.initialize(),
+      LoginManagerStorage.#rustStorage.initialize(),
+    ]).then(async () => {
+      LoginManagerStorage.#logger.log("Oh jeay, I have initialized both stores")
+      try {
+        await LoginManagerStorage.maybeRunRollingMigrationToRustStorage(
+          LoginManagerStorage.#jsonStorage,
+          LoginManagerStorage.#rustStorage
+        );
+      } catch (e) {
+        LoginManagerStorage.#logger.error("Login migration failed", e);
+      }
+
+      if (this.#mirroringObserver) {
+        Services.obs.removeObserver(
+          this.#mirroringObserver,
+          "passwordmgr-storage-changed"
+        );
+      }
+      this.#mirroringObserver = new MirroringObserver(
+        LoginManagerStorage.#rustStorage
+      );
+      Services.obs.addObserver(
+        this.#mirroringObserver,
+        "passwordmgr-storage-changed"
+      );
+
+      LoginManagerStorage.#initialized = true;
+    }).then(() => callback?.());
+  }
+
+  static async maybeRunRollingMigrationToRustStorage(jsonStorage, rustStorage) {
+    LoginManagerStorage.#logger.log("Running login migration...");
+
+    const jsonChecksum = await jsonStorage.computeShasum();
+    const rustCheckpoint = rustStorage.getCheckpoint();
+
+    if (jsonChecksum && jsonChecksum !== rustCheckpoint) {
+      LoginManagerStorage.#logger.log("Checksums differ. Rolling migration required.");
+
+      rustStorage.removeAllLogins();
+      LoginManagerStorage.#logger.log("Cleared existing Rust logins.");
+
+      const logins = await jsonStorage.getAllLogins();
+
+      await rustStorage.addLoginsAsync(logins);
+      LoginManagerStorage.#logger.log(`Successfully migrated ${logins.length} logins.`);
+
+      rustStorage.setCheckpoint(jsonChecksum);
+      LoginManagerStorage.#logger.log("Migration complete. Checkpoint updated.");
+    } else {
+      LoginManagerStorage.#logger.log("Checksums match. No migration needed.");
+    }
+
+    LoginManagerStorage.#logger.log("Login migration finished.");
+  }
+}

--- a/toolkit/components/passwordmgr/storage-json.sys.mjs
+++ b/toolkit/components/passwordmgr/storage-json.sys.mjs
@@ -1098,6 +1098,22 @@ export class LoginManagerStorage_json {
 
     return result;
   }
+
+  // Compute a sha256 sum over the json file; If the file does not exist, return null.
+  // Used for rolling migration.
+  async computeShasum() {
+    let sha;
+    try {
+      sha = await this._store.computeHexDigest("sha256");
+    } catch (e) {
+      // I'd expect this to be a NS_ERROR_FILE_NOT_FOUND, but computeHexDigest
+      // returns NS_ERROR_DOM_NOT_FOUND_ERR instead
+      if (e.result != Cr.NS_ERROR_DOM_NOT_FOUND_ERR) {
+        throw(e);
+      }
+    }
+    return sha;
+  }
 }
 
 ChromeUtils.defineLazyGetter(LoginManagerStorage_json.prototype, "log", () => {

--- a/toolkit/components/passwordmgr/test/unit/xpcshell.toml
+++ b/toolkit/components/passwordmgr/test/unit/xpcshell.toml
@@ -107,6 +107,7 @@ skip-if = ["os == 'android'"]
 skip-if = ["os == 'android'"]
 
 ["test_rust_mirror.js"]
+skip-if = ["os == 'android'"]
 
 ["test_search_schemeUpgrades.js"]
 


### PR DESCRIPTION
* make it a class method of LoginStorage, since `storage-desktop` is not included in the build
* add checkpoint methods to the storage adapters so we don't have to call internals
* use the logger (you can turn it on by changing the pref `signon.debug` in `modules/libpref/init/all.js`)