### PR TITLE
adding telemetry for rolling migration

### DIFF
--- a/toolkit/components/passwordmgr/metrics.yaml
+++ b/toolkit/components/passwordmgr/metrics.yaml
@@ -837,6 +837,68 @@ pwmgr:
     expires: never
     no_lint:
       - UNIT_IN_NAME
+  
+  diff_saved_passwords_rust:
+    type: quantity
+    unit: passwords
+    lifetime: application
+    description: |
+      Records any difference in the number of saved logins between JSON 
+      storage and Rust storage.
+    bugs:
+      - TODO open Bug
+    data_reviews:
+      - TODO submit Datareview
+    notification_emails:
+      - passwords-dev@mozilla.org
+    expires: never
+    no_lint:
+      - UNIT_IN_NAME
+  
+  rust_migration_failure:
+  type: event
+  description: >
+    Records failures from operations in the Rust password store, including 
+    the operation type and error message.
+  bugs:
+    - TODO open Bug
+  data_reviews:
+    - TODO submit Datareview
+  notification_emails:
+    - passwords-dev@mozilla.org
+  expires: never
+  extra_keys:
+    operation:
+      description: >
+        The type of operation that failed (e.g. "add", "modify", "remove", "migration", etc.).
+      type: string
+    error_message:
+      description: >
+        The error message or exception string from the failure.
+      type: string
+
+  rust_invalid_login_format:
+    type: labeled_counter
+    unit: passwords
+    lifetime: application
+    description: |
+      Counts how often logins contain non-ASCII characters in the `origin` or
+      `formActionOrigin` are automatically converted
+      to Punycode for rust store. Labels distinguish which field was affected.
+    labels:
+    - dotOrigin
+    - dotFormAction
+    - nonAsciiOrigin
+    - nonAsciiFormAction
+    bugs:
+      - TODO open Bug
+    data_reviews:
+      - TODO submit Datareview
+    notification_emails:
+      - passwords-dev@mozilla.org
+    expires: never
+    no_lint:
+      - UNIT_IN_NAME
 
   saving_enabled:
     type: boolean

--- a/toolkit/components/passwordmgr/storage-desktop.sys.mjs
+++ b/toolkit/components/passwordmgr/storage-desktop.sys.mjs
@@ -13,9 +13,11 @@ ChromeUtils.defineESModuleGetters(lazy, {
 });
 
 class MirroringObserver {
+  #jsonStorage = null;
   #rustStorage = null;
 
-  constructor(rustStorage) {
+  constructor(jsonStorage, rustStorage) {
+    this.#jsonStorage = jsonStorage;
     this.#rustStorage = rustStorage;
   }
 
@@ -33,8 +35,15 @@ class MirroringObserver {
           // - non-ascii origin
           // - single dot origin
           await this.#rustStorage.addLoginsAsync([subject]);
+
+          recordPasswordCountDiff(this.#jsonStorage, this.#rustStorage);
         } catch (e) {
           console.error("mirror-error:", e);
+
+          Glean.pwmgr.rustMigrationFailure.record({
+            operation: "add",
+            error_message: e.message ?? String(e),
+          });
         }
         this.log(`rust-mirror: added login ${subject.guid}.`);
         break;
@@ -48,8 +57,15 @@ class MirroringObserver {
           // - non-ascii origin
           // - single dot origin
           this.#rustStorage.modifyLogin(loginToModify, newLoginData);
+
+          recordPasswordCountDiff(this.#jsonStorage, this.#rustStorage);
         } catch (e) {
           console.error("mirror-error:", e);
+
+          Glean.pwmgr.rustMigrationFailure.record({
+            operation: "modify-login",
+            error_message: e.message ?? String(e),
+          });
         }
         this.log(`rust-mirror: modified login ${loginToModify.guid}.`);
         break;
@@ -58,8 +74,15 @@ class MirroringObserver {
         this.log(`rust-mirror: removing login ${subject.guid}...`);
         try {
           this.#rustStorage.removeLogin(subject);
+
+          recordPasswordCountDiff(this.#jsonStorage, this.#rustStorage);
         } catch (e) {
           console.error("mirror-error:", e);
+
+          Glean.pwmgr.rustMigrationFailure.record({
+            operation: "remove-login",
+            error_message: e.message ?? String(e),
+          });
         }
         this.log(`rust-mirror: removed login ${subject.guid}.`);
         break;
@@ -68,8 +91,15 @@ class MirroringObserver {
         this.log("rust-mirror: removing all logins...");
         try {
           this.#rustStorage.removeAllLogins();
+
+          recordPasswordCountDiff(this.#jsonStorage, this.#rustStorage);
         } catch (e) {
           console.error("mirror-error:", e);
+
+          Glean.pwmgr.rustMigrationFailure.record({
+            operation: "remove-all-logins",
+            error_message: e.message ?? String(e),
+          });
         }
         this.log("rust-mirror: removed all logins.");
         break;
@@ -117,6 +147,11 @@ export class LoginManagerStorage extends LoginManagerStorage_json {
         );
       } catch (e) {
         LoginManagerStorage.#logger.error("Login migration failed", e);
+
+        Glean.pwmgr.rustMigrationFailure.record({
+          operation: "migration",
+          error_message: e.message ?? String(e),
+        });
       }
 
       if (this.#mirroringObserver) {
@@ -126,6 +161,7 @@ export class LoginManagerStorage extends LoginManagerStorage_json {
         );
       }
       this.#mirroringObserver = new MirroringObserver(
+        LoginManagerStorage.#jsonStorage,
         LoginManagerStorage.#rustStorage
       );
       Services.obs.addObserver(
@@ -156,10 +192,19 @@ export class LoginManagerStorage extends LoginManagerStorage_json {
 
       rustStorage.setCheckpoint(jsonChecksum);
       LoginManagerStorage.#logger.log("Migration complete. Checkpoint updated.");
+
+      recordPasswordCountDiff(jsonStore, rustStore);
     } else {
       LoginManagerStorage.#logger.log("Checksums match. No migration needed.");
     }
 
     LoginManagerStorage.#logger.log("Login migration finished.");
   }
+}
+
+function recordPasswordCountDiff(jsonStore, rustStore) {
+  const jsonCount = jsonStore.countLogins("", "", "");
+  const rustCount = rustStore.countLogins("", "", "");
+  const diff = Math.abs(jsonCount - rustCount);
+  Glean.pwmgr.diffSavedPasswordsRust.set(diff);
 }

--- a/toolkit/components/passwordmgr/test/unit/test_telemetry.js
+++ b/toolkit/components/passwordmgr/test/unit/test_telemetry.js
@@ -123,3 +123,172 @@ add_task(function test_settings_statistics() {
     );
   }
 });
+
+/*
+ * Tests that the number of saved logins is appropriately reported to
+ * the rust storage.
+ */
+add_task(async function test_logins_diff_count_rust_storage() {
+  const expectedDiff = 0;
+
+  // Wait for observer to ensure that Rust metric was set
+  await TestUtils.waitForCondition(() => {
+    return Glean.pwmgr.diffSavedPasswordsRust.testGetValue() === expectedDiff;
+  }, `Waiting for Rust telemetry to report ${expectedDiff} saved passwords`);
+
+  Assert.equal(
+    Glean.pwmgr.diffSavedPasswordsRust.testGetValue(),
+    expectedDiff,
+    "Rust and JSON storage should have the same number of saved passwords"
+  );
+});
+
+/*
+ * Tests that an error is logged when adding an invalid login to the Rust store.
+ * The Rust store is stricter than the JSON store and rejects some formats,
+ * such as certain non-ASCII origins.
+ */
+add_task(async function test_rust_mirror_addLogin_failure() {
+  // Flush + reset Glean state to start clean
+  await Services.fog.testFlushAllChildren();
+  Services.fog.testResetFOG();
+
+  const badLogin = LoginTestUtils.testData.formLogin({
+    origin: "https://.", // invalid origin for Rust
+    formActionOrigin: "https://example.org/",
+    username: "baduser",
+    password: "badpass",
+  });
+
+  info("Attempting to add login with invalid origin that Rust cannot parse...");
+
+  // addLoginAsync should succeed in JSON, but Rust will fail in the mirror
+  await Services.logins.addLoginAsync(badLogin);
+
+  // Wait for microtask + Rust mirror flush
+  await new Promise(resolve => Services.tm.dispatchToMainThread(resolve));
+  await Services.fog.testFlushAllChildren();
+
+  const events = Glean.pwmgr.rustMigrationFailure.testGetValue();
+  Assert.ok(
+    events.length >= 1,
+    "At least one rustMigrationFailure event was recorded"
+  );
+
+  const addEvent = events.find(e => e.extra?.operation === "add");
+  Assert.ok(addEvent, "An 'add' failure event was recorded");
+
+  Assert.ok(
+    typeof addEvent.extra.error_message === "string" &&
+      !!addEvent.extra.error_message.length,
+    "The error_message field should contain the error string"
+  );
+});
+
+// TODO tests for login remove, intit, migration fail etc
+
+/*
+ * Tests that we collect telemetry if non-ASCII origins get punycoded.
+ */
+add_task(async function test_punycode_origin_metric() {
+  await Services.fog.testFlushAllChildren();
+  Services.fog.testResetFOG();
+
+  const badOrigin = "https://münich.example.com";
+  const login = LoginTestUtils.testData.formLogin({
+    origin: badOrigin,
+    formActionOrigin: "https://example.com",
+    username: "user1",
+    password: "pass1",
+  });
+
+  await Services.logins.addLoginAsync(login);
+
+  await TestUtils.waitForCondition(
+    () => Glean.pwmgr.invalidLoginFormat.nonAsciiOrigin.testGetValue() === 1
+  );
+
+  Assert.equal(
+    Glean.pwmgr.originPunycodeUsed.origin.testGetValue(),
+    1,
+    "Punycode telemetry for `origin` should be incremented"
+  );
+});
+
+/*
+ * Tests that we collect telemetry if non-ASCII formorigins get punycoded.
+ */
+add_task(async function test_punycode_formActionOrigin_metric() {
+  await Services.fog.testFlushAllChildren();
+  Services.fog.testResetFOG();
+
+  const badFormActionOrigin = "https://münich.example.org";
+  const login = LoginTestUtils.testData.formLogin({
+    origin: "https://example.org",
+    formActionOrigin: badFormActionOrigin,
+    username: "user2",
+    password: "pass2",
+  });
+
+  await Services.logins.addLoginAsync(login);
+
+  await TestUtils.waitForCondition(
+    () => Glean.pwmgr.invalidLoginFormat.nonAsciiFormOrigin.testGetValue() === 1
+  );
+
+  Assert.equal(
+    Glean.pwmgr.originPunycodeUsed.formActionOrigin.testGetValue(),
+    1,
+    "Punycode telemetry for `formActionOrigin` should be incremented"
+  );
+});
+
+/*
+ * Tests that we collect telemetry for single dot in origin
+ */
+add_task(async function test_dot_in_origin_triggers_telemetry() {
+  await Services.fog.testFlushAllChildren();
+  Services.fog.testResetFOG();
+
+  const badLogin = LoginTestUtils.testData.formLogin({
+    origin: ".", // technically valid in JSON, problematic for Rust
+    formActionOrigin: "https://example.org",
+    username: "dotuser",
+    password: "dotpass",
+  });
+
+  await Services.logins.addLoginAsync(badLogin);
+
+  await Services.fog.testFlushAllChildren();
+
+  Assert.equal(
+    Glean.pwmgr.invalidLoginFormat.dotOrigin.testGetValue(),
+    1,
+    "Glean telemetry for dotOrigin should be incremented"
+  );
+});
+
+/*
+ * Tests that we collect telemetry for single dot in formorigin
+ */
+add_task(async function test_dot_in_formActionOrigin_triggers_telemetry() {
+  await Services.fog.testFlushAllChildren();
+  Services.fog.testResetFOG();
+
+  const badLogin = LoginTestUtils.testData.formLogin({
+    origin: "https://example.com",
+    formActionOrigin: ".", // triggers telemetry
+    username: "formuser",
+    password: "formpass",
+  });
+
+  await Services.logins.addLoginAsync(badLogin);
+
+  await Services.fog.testFlushAllChildren();
+
+  Assert.equal(
+    Glean.pwmgr.invalidLoginFormat.dotFormActionOrigin.testGetValue(),
+    1,
+    "Glean telemetry for dotFormActionOrigin should be incremented"
+  );
+});


### PR DESCRIPTION
Adding telemetry to track discrepancies between the legacy JSON-based login storage and the new Rust-based login storage, as part of the migration and mirroring process.

New Glean metrics:
- pwmgr.diffSavedPasswordsRust
- pwmgr.RustMigrationFailure
- pwmgr.RustInvalidLoginFormat