### PR TITLE
adding telemetry probe to track migration performance

### DIFF
--- a/toolkit/components/passwordmgr/LoginManagerRustMirror.sys.mjs
+++ b/toolkit/components/passwordmgr/LoginManagerRustMirror.sys.mjs
@@ -43,6 +43,13 @@ function recordMigrationFailure(operation, error) {
   });
 }
 
+function recordMigrationPerformance(durationMs, totalLogins) {
+  Glean.pwmgr.rustMigrationPerformance.record({
+    duration_ms: String(durationMs),
+    total_logins: String(totalLogins),
+  });
+}
+
 export class LoginManagerRustMirror {
   #logger = null;
   #jsonStorage = null;
@@ -225,11 +232,15 @@ export class LoginManagerRustMirror {
 
     this.#logger.log("Checksums differ. Rolling migration required.");
 
+    const t0 = Date.now();
+    let totalLogins = 0;
+
     try {
       this.#rustStorage.removeAllLogins();
       this.#logger.log("Cleared existing Rust logins.");
 
       const logins = await this.#jsonStorage.getAllLogins();
+      totalLogins = logins.length;
 
       const results = await this.#rustStorage.addLoginsAsync(logins, true);
       for (const { error } of results) {
@@ -246,6 +257,8 @@ export class LoginManagerRustMirror {
 
       this.#logger.log("Login migration finished.");
     } finally {
+      const duration = Date.now() - t0;
+      recordMigrationPerformance(duration, totalLogins);
       this.#rollingMigrationInProgress = false;
     }
   }

--- a/toolkit/components/passwordmgr/metrics.yaml
+++ b/toolkit/components/passwordmgr/metrics.yaml
@@ -906,9 +906,9 @@ pwmgr:
       One record per rolling migration run, recording duration and total number 
       of logins migrated.
     bugs:
-      - https://bugzil.la/1981812
+      - https://bugzil.la/1985800
     data_reviews:
-      - https://bugzil.la/1981812
+      - https://bugzil.la/1985800
     data_sensitivity:
       - technical
     notification_emails:

--- a/toolkit/components/passwordmgr/metrics.yaml
+++ b/toolkit/components/passwordmgr/metrics.yaml
@@ -900,6 +900,30 @@ pwmgr:
       - passwords-dev@mozilla.org
     expires: never
 
+  rust_migration_performance:
+    type: event
+    description: >
+      One record per rolling migration run, recording duration and total number 
+      of logins migrated.
+    bugs:
+      - https://bugzil.la/1981812
+    data_reviews:
+      - https://bugzil.la/1981812
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - passwords-dev@mozilla.org
+    expires: never
+    extra_keys:
+      total_logins:
+        description: >
+          Total number of logins migrated during this run.
+        type: string
+      duration_ms:
+        description: >
+          Duration of the migration in milliseconds.
+        type: string
+
   saving_enabled:
     type: boolean
     lifetime: application

--- a/toolkit/components/passwordmgr/test/unit/test_rust_mirror.js
+++ b/toolkit/components/passwordmgr/test/unit/test_rust_mirror.js
@@ -560,6 +560,47 @@ add_task(async function test_single_dot_in_origin() {
   const evt = Glean.pwmgr.rustIncompatibleLoginFormat.dotOrigin.testGetValue();
   Assert.equal(evt, 1, "event has been emitted");
 
-  await LoginTestUtils.clearData();
+  LoginTestUtils.clearData();
+  rustStorage.removeAllLogins();
+});
+
+/**
+ * Tests that a rust_migration_performance event is recorded after migration,
+ * containing both duration and total number of migrated logins.
+ */
+add_task(async function test_migration_performance_probe() {
+  Services.fog.testResetFOG();
+
+  const login = TestData.formLogin({
+    username: "perf-user",
+    password: "perf-password",
+  });
+  await Services.logins.addLoginAsync(login);
+
+  const rustStorage = new LoginManagerRustStorage();
+  await rustStorage.initialize();
+  const mirror = new LoginManagerRustMirror(Services.logins, rustStorage);
+
+  // Force migration to run
+  sinon.stub(rustStorage, "getCheckpoint").returns("force-migration");
+
+  await mirror.enable();
+  await mirror.maybeRunRollingMigrationToRustStorage();
+
+  const evt = Glean.pwmgr.rustMigrationPerformance.testGetValue();
+  Assert.ok(evt, "rustMigrationPerformance event should have been emitted");
+  Assert.equal(
+    evt.extra?.total_logins,
+    "1",
+    "event should record total migrated logins"
+  );
+  Assert.ok(
+    parseInt(evt.extra?.duration_ms, 10) >= 0,
+    "event should record non-negative duration in ms"
+  );
+
+  mirror.disable();
+  sinon.restore();
+  LoginTestUtils.clearData();
   rustStorage.removeAllLogins();
 });


### PR DESCRIPTION
- Introduces a new Glean event rust_migration_performance to track the performance of rolling migrations from JSON to Rust logins storage, which records duration (ms) and total number of logins migrated for each migration run.

- Added helper recordMigrationPerformance() in LoginManagerRustMirror.

- Defined metric in metrics.yaml under pwmgr.

- Added unit test test_migration_performance_probe to verify event emission.